### PR TITLE
chore(docker): improve performance of app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,18 @@ RUN xcaddy build
 ########
 
 #### Stage 1 ####
-FROM node:18.16.0-alpine as builder
+FROM node:18-bookworm-slim as builder
 
 # Copy and set directory
 COPY ./root /var/www/html
-WORKDIR /var/www/html 
+WORKDIR /var/www/html
 
 # Install deps and build the site
 RUN yarn && yarn build
 ########
 
 #### Stage 2 ####
-FROM node:18.16.0-alpine as prod
+FROM node:18-bookworm-slim as prod
 
 # Copy caddy stuff
 COPY --from=caddy-builder /usr/bin/caddy /usr/bin/caddy
@@ -38,7 +38,7 @@ RUN yarn global add pm2
 CMD ["/bin/sh", "-c", "pm2 start /var/www/html/ecosystem.config.js & caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]
 
 #### Stage 2 DEV ####
-FROM node:18.16.0-alpine as dev
+FROM node:18-bookworm-slim as dev
 
 WORKDIR /var/www/html
 CMD yarn && yarn dev


### PR DESCRIPTION
# What's Changed?

- Change Docker image `node:18.16.0-alpine` to `node:18-bookworm-slim`
    - alpine Linux does not include `glibc` by default. But, Node.js depends on `glibc`. This causes lower performance than default Node.js image.

# Image Size Changes
- Before: 175MB
- After: 242MB
![image](https://github.com/ModWorkshop/mws-frontend/assets/18034370/863d335a-0489-499a-bece-34baf6915d74)

# Additional Information
- Choose `distroless` image (https://github.com/GoogleContainerTools/distroless) if decreasing image size.
    - We need to change the image to `node:18-bullseye-slim` on builder stage because of `glibc` issue if using `distroless`
    - ref: https://github.com/GoogleContainerTools/distroless/issues/1342 
        - (The lang is Go in this situation, but it might happen on Node.js.)
