### PR TITLE
Dockerfile improvement

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1
 FROM dunglas/frankenphp:1.8.0-php8.3-bookworm AS build
 
-RUN apt-get update && apt-get install supervisor -y
+RUN apt-get update && apt-get install supervisor -y --no-install-recommends
 
 # # Using heredoc from dockerfile:1.4 (ref: https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
 # # PHP ini configuration
@@ -60,7 +60,7 @@ COPY --chown=nobody . /app
 COPY conf.d/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY conf.d/Caddyfile /etc/caddy/Caddyfile
 
-RUN apt-get update && apt-get install cron -y \
+RUN apt-get update && apt-get install cron -y --no-install-recommends \
     # && chown nobody:nogroup /usr/sbin/cron \
     # && setcap cap_setgid=ep /usr/sbin/cron \
     && mkdir /etc/crontabs \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,20 +9,13 @@ RUN apt-get update && apt-get install supervisor -y --no-install-recommends
 RUN install-php-extensions \
     apcu \
     ffi \
-    simplexml \
-    tokenizer \
-    fileinfo \
     redis \
     pdo_mysql \
-    pdo \
     exif \
     pdo_pgsql \
-    xmlwriter \
     pcntl \
-    posix \
     zip \
-    vips \
-    opcache
+    vips
 
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1
 FROM dunglas/frankenphp:1.8.0-php8.3-bookworm AS build
 
-RUN apt-get update && apt-get install supervisor -y --no-install-recommends
+RUN apt-get update && apt-get install -y --no-install-recommends supervisor
 
 # # Using heredoc from dockerfile:1.4 (ref: https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
 # # PHP ini configuration
@@ -53,7 +53,7 @@ COPY --chown=nobody . /app
 COPY conf.d/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY conf.d/Caddyfile /etc/caddy/Caddyfile
 
-RUN apt-get update && apt-get install cron -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends cron \
     # && chown nobody:nogroup /usr/sbin/cron \
     # && setcap cap_setgid=ep /usr/sbin/cron \
     && mkdir /etc/crontabs \

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:17.2
 
-RUN apt update && apt install -y postgresql-17-semver
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-17-semver
 
 CMD ["postgres"]


### PR DESCRIPTION
## Overview

- Add `--no-install-recommends` option at `apt-get install`
  - This option suppresses installing non-required packages
  - ref: [apt-get(8) — apt — Debian bookworm — Debian Manpages](https://manpages.debian.org/bookworm/apt/apt-get.8.en.html)
- Change `apt` command to `apt-get` command
  - `apt` is interactive command, while `apt-get` is 
  - ref: [Chapter 2. Debian package management](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_literal_apt_literal_vs_literal_apt_get_literal_literal_apt_cache_literal_vs_literal_aptitude_literal)
- Remove default installed php extensions
  - See below

<details><summary>Result (install-php-extensions)</summary>
<p>

```
$ docker run --rm -it dunglas/frankenphp:1.8.0-php8.3-bookworm /bin/bash
root@cbe99254c495:/app# install-php-extensions \
    apcu \
    ffi \
    simplexml \
    tokenizer \
    fileinfo \
    redis \
    pdo_mysql \
    pdo \
    exif \
    pdo_pgsql \
    xmlwriter \
    pcntl \
    posix \
    zip \
    vips \
    opcache
install-php-extensions v.2.8.5
#StandWithUkraine
### WARNING Module already installed: simplexml ###
### WARNING Module already installed: tokenizer ###
### WARNING Module already installed: fileinfo ###
### WARNING Module already installed: pdo ###
### WARNING Module already installed: xmlwriter ###
### WARNING Module already installed: posix ###
### WARNING Module already installed: opcache ###
--- strip ---
```

</p>
</details> 

## Testing

Build/Run on local:

```sh
# on root project
$ docker build -t mws-backend --target dev --no-cache ./backend
$ docker compose up # or docker compose up --build
```

## Comment

Adding `rm -rf /var/lib/apt/lists/*` makes docker images slim. However, some command (such as `install-php-extensions`) re-create it, and I thought searching what commands re-created would be a bit hard. So, this PR doesn't contain that improvement.